### PR TITLE
Block messages by ip and email

### DIFF
--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -214,7 +214,6 @@ function get_all_services(): array
 {
   return get_field_object( 'field_5b5ed686ddd58' )[ 'choices' ];
 }
-<<<<<<< HEAD
 
 /**
  * Get all terms related to wholesalers with a special offer
@@ -263,5 +262,3 @@ function is_special_offer_limit_exceeded(): bool
   
   return ( $wp_query->found_posts >= $special_offer_limit );
 }
-=======
->>>>>>> Remove unused function

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -214,6 +214,7 @@ function get_all_services(): array
 {
   return get_field_object( 'field_5b5ed686ddd58' )[ 'choices' ];
 }
+<<<<<<< HEAD
 
 /**
  * Get all terms related to wholesalers with a special offer
@@ -262,3 +263,5 @@ function is_special_offer_limit_exceeded(): bool
   
   return ( $wp_query->found_posts >= $special_offer_limit );
 }
+=======
+>>>>>>> Remove unused function

--- a/lib/setup.php
+++ b/lib/setup.php
@@ -426,6 +426,14 @@ function handle_wholesaler_message() {
   $message = sanitize_textarea_field( $_POST[ 'message' ] );
   $wholesaler_id = intval( $_POST[ 'wholesaler_id' ] );
 
+  // WordPress comments blacklist check
+  $user_url = '';
+  $user_ip = $_SERVER['REMOTE_ADDR'];
+  $user_ip = preg_replace( '/[^0-9a-fA-F:., ]/', '', $user_ip );
+  $user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '';
+  $user_agent = substr( $user_agent, 0, 254 );
+  $is_blacklisted = wp_blacklist_check( $name, $email, $user_url, $message, $user_ip, $user_agent );
+
   // Insert wholesaler message post
   $postarr = [
     'post_type' => 'wholesaler_message',
@@ -435,9 +443,16 @@ function handle_wholesaler_message() {
       'email' => $email,
       'message' => $message,
       'wholesaler' => $wholesaler_id,
+      'agent' => $user_agent,
+      'ip' => $user_ip,
+      'spam' => $is_blacklisted,
     ],
   ];
   wp_insert_post( $postarr );
+
+  if ( $is_blacklisted ) {
+    wp_die();
+  }
 
   // Increase wholesaler contact count
   $wholesaler_contact_count = get_post_meta( $wholesaler_id, 'contact_count', true );


### PR DESCRIPTION
Využití WP funkce pro blokování komentářů, pro blokování kontaktních zpráv velkoobchodům.